### PR TITLE
feat: add login form on home page

### DIFF
--- a/components/AvatarPicker/index.tsx
+++ b/components/AvatarPicker/index.tsx
@@ -1,0 +1,31 @@
+import Image from 'next/image'
+import type { Avatar } from '../../types'
+import { avatars } from '../../shared/const'
+import { AvatarItem, AvatarWrapper } from './styles'
+
+type Props = {
+  value: Avatar
+  onSelect: (avatar: Avatar) => void
+}
+
+export const AvatarPicker: React.FC<Props> = ({ value, onSelect }) => {
+  return (
+    <ul>
+      {avatars.map((avatar) => (
+        <AvatarItem key={avatar}>
+          <AvatarWrapper
+            isSelected={value === avatar}
+            onClick={() => onSelect(avatar)}
+          >
+            <Image
+              src={`/${avatar}`}
+              alt={`Avatar - ${avatar}`}
+              width={36}
+              height={36}
+            />
+          </AvatarWrapper>
+        </AvatarItem>
+      ))}
+    </ul>
+  )
+}

--- a/components/AvatarPicker/styles.ts
+++ b/components/AvatarPicker/styles.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+import { borderRadius, getBorder, primaryColor } from '../../shared/styles'
+
+type AvatarProps = {
+  isSelected: boolean
+}
+
+export const AvatarItem = styled.li`
+  display: inline-block;
+  margin-right: 1rem;
+`
+
+export const AvatarWrapper = styled.div<AvatarProps>`
+  width: 38px;
+  height: 38px;
+  border: ${({ isSelected }) =>
+    getBorder(isSelected ? primaryColor : undefined)};
+  border-radius: ${borderRadius};
+  cursor: pointer;
+`

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -1,0 +1,5 @@
+import { ButtonElement } from './styles'
+
+export const Button: React.FC = ({ children }) => {
+  return <ButtonElement type="submit">{children}</ButtonElement>
+}

--- a/components/Button/styles.ts
+++ b/components/Button/styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+import { borderRadius, primaryColor } from '../../shared/styles'
+
+export const ButtonElement = styled.button`
+  width: 100%;
+  color: #fff;
+  background-color: ${primaryColor};
+  border-radius: ${borderRadius};
+  padding: 0.5rem 1rem;
+  border: 0;
+  cursor: pointer;
+`

--- a/components/ChannelList/index.tsx
+++ b/components/ChannelList/index.tsx
@@ -1,20 +1,20 @@
 import Link from 'next/link'
-import { Title, List, ListItem, ItemLink } from './styles'
+import { Title, ItemLink } from './styles'
 
 export const ChannelList = () => {
   return (
     <>
       <Title>Channels</Title>
-      <List>
-        <ListItem>
+      <ul>
+        <li>
           <Link href="/channels/marketing" passHref>
             <ItemLink>#marketing</ItemLink>
           </Link>
           <Link href="/channels/programming" passHref>
             <ItemLink>#programming</ItemLink>
           </Link>
-        </ListItem>
-      </List>
+        </li>
+      </ul>
     </>
   )
 }

--- a/components/ChannelList/styles.ts
+++ b/components/ChannelList/styles.ts
@@ -5,14 +5,6 @@ export const Title = styled.h2`
   margin: 0.3rem 0 0.25rem;
 `
 
-export const List = styled.ul`
-  list-style-type: none;
-  padding: 0;
-  margin: 0;
-`
-
-export const ListItem = styled.li``
-
 export const ItemLink = styled.a`
   display: block;
   padding: 0.25rem 0;

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -1,0 +1,24 @@
+import { InputElement, Label, LabelText } from './styles'
+
+type Props = {
+  onChange: (value: string) => void
+  value?: string
+  placeholder?: string
+  required?: boolean
+}
+
+export const Input: React.FC<Props> = ({
+  value,
+  onChange,
+  placeholder,
+  required,
+}) => {
+  return (
+    <InputElement
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      required={required}
+    />
+  )
+}

--- a/components/Input/styles.ts
+++ b/components/Input/styles.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+import {
+  getBorder,
+  borderRadius,
+  darkGrey,
+  grey,
+  primaryColor,
+  transitionTime,
+} from '../../shared/styles'
+
+export const InputElement = styled.input`
+  width: 100%;
+  padding: 0.5rem;
+  border: ${getBorder()};
+  border-radius: ${borderRadius};
+  outline: none;
+  transition: border ${transitionTime};
+
+  &:hover,
+  &:focus {
+    border: ${getBorder(primaryColor)};
+  }
+
+  ::placeholder {
+    color: ${grey};
+  }
+`
+
+export const Label = styled.label`
+  display: block;
+  margin-bottom: 1rem;
+`
+
+export const LabelText = styled.div`
+  color: ${darkGrey};
+  margin-bottom: 0.25rem;
+`

--- a/components/Label/index.tsx
+++ b/components/Label/index.tsx
@@ -1,0 +1,14 @@
+import { LabelElement, LabelText } from './styles'
+
+type Props = {
+  label: string
+}
+
+export const Label: React.FC<Props> = ({ children, label }) => {
+  return (
+    <LabelElement>
+      <LabelText>{label}</LabelText>
+      {children}
+    </LabelElement>
+  )
+}

--- a/components/Label/styles.ts
+++ b/components/Label/styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+import { darkGrey } from '../../shared/styles'
+
+export const LabelElement = styled.label`
+  display: block;
+  margin-bottom: 1rem;
+`
+
+export const LabelText = styled.div`
+  color: ${darkGrey};
+  margin-bottom: 0.25rem;
+`

--- a/components/LoginForm/index.tsx
+++ b/components/LoginForm/index.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { Input } from '../Input'
+import { Button } from '../Button'
+import { Label } from '../Label'
+import { AvatarPicker } from '../AvatarPicker'
+import type { Avatar } from '../../types'
+import { avatars } from '../../shared/const'
+import { useCurrentUser } from '../../hooks/useCurrentUser'
+import { LoginOuter, InputsWrapper } from './styles'
+
+export const LoginForm = () => {
+  const router = useRouter()
+  const [, setCurrentUser] = useCurrentUser()
+  const [channelName, setChannelName] = useState<string>()
+  const [userName, setUserName] = useState<string>()
+  const [avatar, setAvatar] = useState<Avatar>(avatars[0])
+
+  const handleSubmit = (e: React.SyntheticEvent) => {
+    e.preventDefault()
+
+    if (userName && avatar && channelName) {
+      setCurrentUser({ userName, avatar, channels: [channelName] })
+      router.push(`/channels/${channelName}`)
+    }
+  }
+
+  return (
+    <LoginOuter>
+      <form onSubmit={handleSubmit}>
+        <InputsWrapper>
+          <Label label="Channel name">
+            <Input
+              value={channelName}
+              placeholder="Create or join channel name"
+              required
+              onChange={(value) => setChannelName(value.replace(' ', '-'))}
+            />
+          </Label>
+          <Label label="User name">
+            <Input
+              value={userName}
+              onChange={setUserName}
+              placeholder="Add user name"
+              required
+            />
+          </Label>
+          <Label label="Avatar">
+            <AvatarPicker value={avatar} onSelect={setAvatar} />
+          </Label>
+        </InputsWrapper>
+        <Button>Join Channel</Button>
+      </form>
+    </LoginOuter>
+  )
+}

--- a/components/LoginForm/styles.ts
+++ b/components/LoginForm/styles.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+
+export const LoginOuter = styled.div`
+  max-width: 400px;
+  width: 100%;
+`
+
+export const InputsWrapper = styled.div`
+  margin-bottom: 2rem;
+`

--- a/components/LoginLayout/index.tsx
+++ b/components/LoginLayout/index.tsx
@@ -1,0 +1,10 @@
+import { Layout } from './styles'
+import { LoginForm } from '../LoginForm'
+
+export const LoginLayout = () => {
+  return (
+    <Layout>
+      <LoginForm />
+    </Layout>
+  )
+}

--- a/components/LoginLayout/styles.ts
+++ b/components/LoginLayout/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const Layout = styled.main`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100vh;
+`

--- a/components/Message/styles.ts
+++ b/components/Message/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { borderRadius } from '../../shared/styles'
+import { borderRadius, darkGrey } from '../../shared/styles'
 
 export const MessageOuter = styled.div`
   display: flex;
@@ -28,7 +28,7 @@ export const UserName = styled.strong``
 
 export const DateTime = styled.div`
   padding-left: 0.25rem;
-  color: #aaa;
+  color: ${darkGrey};
 `
 
 export const Text = styled.p`

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react'
+import { useRouter } from 'next/router'
+import type { User } from '../types'
+
+const userKey = 'chat-app-user'
+
+const isSSR = typeof window === 'undefined'
+
+// The user data should came from an API call to pull it from the server
+// For this prototype we save it just in localStorage and use it from there
+export const useCurrentUser = () => {
+  const router = useRouter()
+  const [user, setUser] = useState<User>(() => {
+    if (isSSR) {
+      return
+    }
+
+    const userString = localStorage.getItem(userKey)
+    try {
+      return userString !== null ? JSON.parse(userString) : undefined
+    } catch (error) {
+      // Here we can show also an Error message to the user before/after redirecting to login page
+      localStorage.remove(userKey)
+      router.push('/')
+    }
+  })
+
+  const saveUser = useCallback((user: User) => {
+    localStorage.setItem(userKey, JSON.stringify(user))
+    setUser(user)
+  }, [])
+
+  return [user, saveUser] as const
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,31 @@
+import { DocumentContext } from 'next/document'
+import Document from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,8 @@
 import type { NextPage } from 'next'
+import { LoginLayout } from '../components/LoginLayout'
 
 const Home: NextPage = () => {
-  return <div>Hello</div>
+  return <LoginLayout />
 }
 
 export default Home

--- a/shared/const.ts
+++ b/shared/const.ts
@@ -1,0 +1,8 @@
+import type { Avatar } from '../types'
+
+export const avatars: Avatar[] = [
+  'avatar-1.png',
+  'avatar-2.png',
+  'avatar-3.png',
+  'avatar-4.png',
+]

--- a/shared/styles.ts
+++ b/shared/styles.ts
@@ -1,5 +1,6 @@
-export const primaryColor = '#14279B';
-export const grey = 'rgba(170, 170, 170, 0.26)'
-export const getBorder = (color = grey) => `1px solid ${color}`;
-export const borderRadius = '0.25rem';
-export const transitionTime = '1s' 
+export const primaryColor = '#14279B'
+export const grey = '#d9d9d9'
+export const darkGrey = '#aaa'
+export const getBorder = (color = grey) => `1px solid ${color}`
+export const borderRadius = '0.25rem'
+export const transitionTime = '1s'

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,3 +15,9 @@ a {
 * {
   box-sizing: border-box;
 }
+
+ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,11 @@
+export type Avatar =
+  | 'avatar-1.png'
+  | 'avatar-2.png'
+  | 'avatar-3.png'
+  | 'avatar-4.png'
+
+export type User = {
+  userName: string
+  avatar: Avatar
+  channels: string[]
+}


### PR DESCRIPTION
This PR adds a login form on the home page. The user is required to enter - user name, channel name to create or join and select an avatar. Once the form is filled in correctly the user data is saved in local storage and used later in the App. The user data should be saved on the server and read from there with an API call however for this prototype it is saved in local storage. 

![image](https://user-images.githubusercontent.com/10707142/147214917-4215a2b2-be2a-4e29-9eea-481857b25abd.png)


