### PR TITLE
feat: save new channel

### DIFF
--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -1,5 +1,10 @@
 import { ButtonElement } from './styles'
+import { Props } from './types'
 
-export const Button: React.FC = ({ children }) => {
-  return <ButtonElement type="submit">{children}</ButtonElement>
+export const Button: React.FC<Props> = ({ children, variant = 'primary' }) => {
+  return (
+    <ButtonElement variant={variant} type="submit">
+      {children}
+    </ButtonElement>
+  )
 }

--- a/components/Button/styles.ts
+++ b/components/Button/styles.ts
@@ -1,10 +1,12 @@
 import styled from 'styled-components'
-import { borderRadius, primaryColor } from '../../shared/styles'
+import { borderRadius, primaryColor, secondaryColor } from '../../shared/styles'
+import { Props } from './types'
 
-export const ButtonElement = styled.button`
+export const ButtonElement = styled.button<Props>`
   width: 100%;
   color: #fff;
-  background-color: ${primaryColor};
+  background-color: ${({ variant }) =>
+    variant === 'primary' ? primaryColor : secondaryColor};
   border-radius: ${borderRadius};
   padding: 0.5rem 1rem;
   border: 0;

--- a/components/Button/types.ts
+++ b/components/Button/types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  variant?: 'primary' | 'secondary'
+}

--- a/components/ChannelLayout/index.tsx
+++ b/components/ChannelLayout/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { Layout, Aside, Header, Main, Title, Footer } from './styles'
 import { MessageForm } from '../MessageForm'
 import { ChannelList } from '../ChannelList'
+import { ChannelNameForm } from '../ChannelNameForm'
 import { MessageList } from '../MessageList'
 import { useSocket } from '../../hooks/useSocket'
 import { useCurrentUser } from '../../hooks/useCurrentUser'
@@ -11,17 +12,29 @@ type Props = {
 }
 
 export const ChannelLayout: React.FC<Props> = ({ channel }) => {
-  const [{ name, avatar }] = useCurrentUser()
+  const { user, addChannel } = useCurrentUser()
   const socket = useSocket(channel)
 
   const handleSubmit = (message: string) => {
+    const { name, avatar } = user
     socket?.emit('chat-message', { name, avatar, message })
   }
+
+  useEffect(() => {
+    // Add chanel in case a user joins a new channel
+    const hasChannel = user.channels.some(
+      (userChannel) => userChannel === channel
+    )
+    if (!hasChannel) {
+      addChannel(channel)
+    }
+  }, [user, channel, addChannel])
 
   return (
     <Layout>
       <Aside>
-        <ChannelList />
+        <ChannelList activeChannel={channel} />
+        <ChannelNameForm />
       </Aside>
       <Header>
         <Title>#{channel}</Title>

--- a/components/ChannelLayout/styles.ts
+++ b/components/ChannelLayout/styles.ts
@@ -8,7 +8,7 @@ export const Layout = styled.div`
     'aside main'
     'aside footer';
   grid-template-rows: auto 1fr auto;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 260px 1fr;
   grid-row-gap: 0;
   grid-column-gap: 0;
   height: 100vh;
@@ -20,6 +20,10 @@ export const Aside = styled.aside`
   background: #4b4e53;
   color: #fff;
   padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
 `
 export const Header = styled.header`
   grid-area: header;

--- a/components/ChannelList/index.tsx
+++ b/components/ChannelList/index.tsx
@@ -1,20 +1,28 @@
 import Link from 'next/link'
+import { useCurrentUser } from '../../hooks/useCurrentUser'
 import { Title, ItemLink } from './styles'
 
-export const ChannelList = () => {
+type Props = {
+  activeChannel: string
+}
+
+export const ChannelList: React.FC<Props> = ({ activeChannel }) => {
+  const { user } = useCurrentUser()
+
   return (
-    <>
+    <div>
       <Title>Channels</Title>
       <ul>
-        <li>
-          <Link href="/channels/marketing" passHref>
-            <ItemLink>#marketing</ItemLink>
-          </Link>
-          <Link href="/channels/programming" passHref>
-            <ItemLink>#programming</ItemLink>
-          </Link>
-        </li>
+        {user?.channels.map((channel) => (
+          <li key={channel}>
+            <Link href={`/channels/${channel}`} passHref>
+              <ItemLink isSelected={activeChannel === channel}>
+                #{channel}
+              </ItemLink>
+            </Link>
+          </li>
+        ))}
       </ul>
-    </>
+    </div>
   )
 }

--- a/components/ChannelList/styles.ts
+++ b/components/ChannelList/styles.ts
@@ -1,12 +1,18 @@
 import styled from 'styled-components'
+import { secondaryColor } from '../../shared/styles'
+
+type ItemLinkProps = {
+  isSelected: boolean
+}
 
 export const Title = styled.h2`
   font-size: 1rem;
   margin: 0.3rem 0 0.25rem;
 `
 
-export const ItemLink = styled.a`
+export const ItemLink = styled.a<ItemLinkProps>`
   display: block;
   padding: 0.25rem 0;
   font-size: 0.9rem;
+  color: ${({ isSelected }) => (isSelected ? secondaryColor : 'white')};
 `

--- a/components/ChannelNameForm/index.tsx
+++ b/components/ChannelNameForm/index.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { Input } from '../Input'
+import { Button } from '../Button'
+import { useCurrentUser } from '../../hooks/useCurrentUser'
+import { modifyChannelName } from '../../shared/utils'
+import { InputWrapper } from './styles'
+
+export const ChannelNameForm = () => {
+  const router = useRouter()
+  const { addChannel } = useCurrentUser()
+  const [channelName, setChannelName] = useState<string>('')
+
+  const handleSubmit = (e: React.SyntheticEvent) => {
+    e.preventDefault()
+
+    if (channelName) {
+      addChannel(channelName)
+      setChannelName('')
+      router.push(`/channels/${channelName}`)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <InputWrapper>
+        <Input
+          required
+          value={channelName}
+          placeholder="Add channel name"
+          onChange={(value) => setChannelName(modifyChannelName(value))}
+        />
+      </InputWrapper>
+      <Button variant="secondary">Create Channel</Button>
+    </form>
+  )
+}

--- a/components/ChannelNameForm/styles.ts
+++ b/components/ChannelNameForm/styles.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components'
+
+export const InputWrapper = styled.div`
+  margin-bottom: 0.5rem;
+`

--- a/components/LoginForm/index.tsx
+++ b/components/LoginForm/index.tsx
@@ -7,13 +7,14 @@ import { AvatarPicker } from '../AvatarPicker'
 import type { Avatar } from '../../types'
 import { avatars } from '../../shared/const'
 import { useCurrentUser } from '../../hooks/useCurrentUser'
+import { modifyChannelName } from '../../shared/utils'
 import { LoginOuter, InputsWrapper } from './styles'
 
 export const LoginForm = () => {
   const router = useRouter()
-  const [, setCurrentUser] = useCurrentUser()
-  const [channelName, setChannelName] = useState<string>()
-  const [name, setName] = useState<string>()
+  const { setCurrentUser } = useCurrentUser()
+  const [channelName, setChannelName] = useState<string>('')
+  const [name, setName] = useState<string>('')
   const [avatar, setAvatar] = useState<Avatar>(avatars[0])
 
   const handleSubmit = (e: React.SyntheticEvent) => {
@@ -34,7 +35,7 @@ export const LoginForm = () => {
               value={channelName}
               placeholder="Create or join channel name"
               required
-              onChange={(value) => setChannelName(value.replace(' ', '-'))}
+              onChange={(value) => setChannelName(modifyChannelName(value))}
             />
           </Label>
           <Label label="User name">

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,33 +1,22 @@
-import { useState, useCallback } from 'react'
-import { useRouter } from 'next/router'
+import { useCallback } from 'react'
 import type { User } from '../types'
-import { isSSR } from '../shared/utils'
+import { useLocalStorage } from './useLocalStorage'
 
 const userKey = 'chat-app-user'
 
 // The user data should came from an API call to pull it from the server
 // For this prototype we save it just in localStorage and use it from there
 export const useCurrentUser = () => {
-  const router = useRouter()
-  const [user, setUser] = useState<User>(() => {
-    if (isSSR) {
-      return
-    }
+  const [user, setCurrentUser] = useLocalStorage<User>(userKey)
 
-    const userString = localStorage.getItem(userKey)
-    try {
-      return userString !== null ? JSON.parse(userString) : undefined
-    } catch (error) {
-      // Here we can show also an Error message to the user before/after redirecting to login page
-      localStorage.remove(userKey)
-      router.push('/')
-    }
-  })
+  const addChannel = useCallback(
+    (channel: string) => {
+      // remove duplicates
+      const channels = [...new Set([channel, ...user.channels])]
+      setCurrentUser({ ...user, channels })
+    },
+    [user, setCurrentUser]
+  )
 
-  const saveUser = useCallback((user: User) => {
-    localStorage.setItem(userKey, JSON.stringify(user))
-    setUser(user)
-  }, [])
-
-  return [user, saveUser] as const
+  return { user, setCurrentUser, addChannel }
 }

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { isSSR } from '../shared/utils'
+
+type KeyValuePair<TKey, TValue> = { key: TKey; value: TValue }
+
+const getLocalStorageChangeEvent = () => {
+  if (isSSR) {
+    return null
+  }
+
+  return class LocalStorageChangeEvent<TValue> extends CustomEvent<
+    KeyValuePair<string, TValue>
+  > {
+    static eventName = 'onLocalStorageChange'
+
+    constructor(detail: KeyValuePair<string, TValue>) {
+      super(LocalStorageChangeEvent.eventName, { detail })
+    }
+
+    static is<T>(event: any): event is LocalStorageChangeEvent<T> {
+      return (
+        !!event &&
+        (event instanceof LocalStorageChangeEvent ||
+          (event.detail && event.type === LocalStorageChangeEvent.eventName))
+      )
+    }
+  }
+}
+
+const LocalStorageChangeEvent = getLocalStorageChangeEvent()
+
+const writeStorage = <TValue>(key: string, value: TValue) => {
+  if (LocalStorageChangeEvent === null) {
+    return
+  }
+
+  localStorage.setItem(
+    key,
+    typeof value === 'object' ? JSON.stringify(value) : `${value}`
+  )
+
+  window.dispatchEvent(new LocalStorageChangeEvent({ key, value }))
+}
+
+export const useLocalStorage = <TValue = string>(key: string) => {
+  const router = useRouter()
+  const [value, setValue] = useState<TValue>(() => {
+    if (isSSR) {
+      return
+    }
+
+    const userString = localStorage.getItem(key)
+    try {
+      return userString !== null ? JSON.parse(userString) : undefined
+    } catch (error) {
+      // Here we can show also an Error message to the user before/after redirecting to login page
+      localStorage.remove(key)
+      router.push('/')
+    }
+  })
+  const state: TValue = value
+  const setState = useCallback((val: TValue) => writeStorage(key, val), [key])
+
+  useEffect(() => {
+    if (LocalStorageChangeEvent === null) {
+      return
+    }
+
+    const onChange = (e: Event) => {
+      if (LocalStorageChangeEvent.is<TValue>(e) && e.detail.key === key) {
+        setValue(e.detail.value)
+      }
+    }
+
+    window.addEventListener(LocalStorageChangeEvent.eventName, onChange)
+
+    return () => {
+      window.removeEventListener(LocalStorageChangeEvent.eventName, onChange)
+    }
+  }, [key, setState])
+
+  return [state, setState] as const
+}

--- a/pages/channels/[channel].tsx
+++ b/pages/channels/[channel].tsx
@@ -6,7 +6,7 @@ import { useCurrentUser } from '../../hooks/useCurrentUser'
 
 const Channel: NextPage = () => {
   const router = useRouter()
-  const [user] = useCurrentUser()
+  const { user } = useCurrentUser()
   const { channel } = router.query
 
   if (typeof channel !== 'string') {

--- a/shared/styles.ts
+++ b/shared/styles.ts
@@ -1,4 +1,5 @@
 export const primaryColor = '#14279B'
+export const secondaryColor = '#119DA4'
 export const grey = '#d9d9d9'
 export const darkGrey = '#aaa'
 export const getBorder = (color = grey) => `1px solid ${color}`

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -1,1 +1,3 @@
 export const isSSR = typeof window === 'undefined'
+
+export const modifyChannelName = (name: string) => name.replace(' ', '-')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "downlevelIteration": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "server/server.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR adds a form to the channel page sidebar to create a new channel. The channel is added to the user data so it can be used on subsequent logins. 

A new custom hook to handle saving data to local storage is also added. 