### PR TITLE
fix: small fixes after deploy

### DIFF
--- a/components/LoginForm/index.tsx
+++ b/components/LoginForm/index.tsx
@@ -30,20 +30,20 @@ export const LoginForm = () => {
     <LoginOuter>
       <form onSubmit={handleSubmit}>
         <InputsWrapper>
-          <Label label="Channel name">
-            <Input
-              value={channelName}
-              placeholder="Create or join channel name"
-              required
-              onChange={(value) => setChannelName(modifyChannelName(value))}
-            />
-          </Label>
           <Label label="User name">
             <Input
               value={name}
               onChange={setName}
               placeholder="Add user name"
               required
+            />
+          </Label>
+          <Label label="Channel name">
+            <Input
+              value={channelName}
+              placeholder="Create or join channel name"
+              required
+              onChange={(value) => setChannelName(modifyChannelName(value))}
             />
           </Label>
           <Label label="Avatar">

--- a/components/MessageForm/styles.ts
+++ b/components/MessageForm/styles.ts
@@ -13,6 +13,7 @@ export const FormInner = styled.div`
   border: ${getBorder()};
   border-radius: ${borderRadius};
   transition: border ${transitionTime};
+  overflow: hidden;
 
   &:hover,
   &:focus {

--- a/pages/channels/[channel].tsx
+++ b/pages/channels/[channel].tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router'
 import type { NextPage } from 'next'
-import { isSSR } from '../../shared/utils'
 import { ChannelLayout } from '../../components/ChannelLayout'
 import { useCurrentUser } from '../../hooks/useCurrentUser'
 
@@ -9,12 +8,15 @@ const Channel: NextPage = () => {
   const { user } = useCurrentUser()
   const { channel } = router.query
 
+  // Wait until the channel is set
   if (typeof channel !== 'string') {
     return null
   }
 
-  if (!isSSR && !user) {
+  // Redirect to login page is no user
+  if (!user) {
     router.push('/')
+    return null
   }
 
   return <ChannelLayout channel={channel} />


### PR DESCRIPTION
This PR fixes a few small issues that were found after the initial deploy:

- Put the name input first on the login page
- Message input bored was cropped due to overflow
- Redirect to login page if there is no user logged in 