### PR TITLE
fix: add channel to message data

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ channelsWorkspace.on('connection', (socket) => {
 
   socket.on(CHAT_MESSAGE, (message) => {
     const date = new Date().toISOString()
-    const data = { ...message, id: getId(), date }
+    const data = { ...message, id: getId(), date, channel }
     messages.push(data)
 
     workspace.emit(CHAT_MESSAGE, data)


### PR DESCRIPTION
This PR fixes an issue where the channel name was not saved in the DB causing messages to not be shown in the UI.